### PR TITLE
remove context from API

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,7 +1,6 @@
 package auth_test
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -15,7 +14,7 @@ func TestBasic(t *testing.T) {
 	m := auth.Basic("username", "password")
 	chain := cliware.NewChain(m)
 	req := cliware.EmptyRequest()
-	chain.Exec(createHandler()).Handle(nil, req)
+	chain.Exec(createHandler()).Handle(req)
 	val, ok := req.Header["Authorization"]
 	if !ok {
 		t.Error("Expected request to have Authorization header, none found.")
@@ -47,7 +46,7 @@ func TestBearer(t *testing.T) {
 	m := auth.Bearer("token")
 	chain := cliware.NewChain(m)
 	req := cliware.EmptyRequest()
-	chain.Exec(createHandler()).Handle(nil, req)
+	chain.Exec(createHandler()).Handle(req)
 	val, ok := req.Header["Authorization"]
 	if !ok {
 		t.Error("Expected request to have Authorization header, none found.")
@@ -67,7 +66,7 @@ func TestCustom(t *testing.T) {
 	m := auth.Custom(header)
 	chain := cliware.NewChain(m)
 	req := cliware.EmptyRequest()
-	chain.Exec(createHandler()).Handle(nil, req)
+	chain.Exec(createHandler()).Handle(req)
 	val, ok := req.Header["Authorization"]
 	if !ok {
 		t.Error("Expected request to have Authorization header, none found.")
@@ -82,7 +81,7 @@ func TestCustom(t *testing.T) {
 }
 
 func createHandler() cliware.Handler {
-	return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
+	return cliware.HandlerFunc(func(req *http.Request) (resp *http.Response, err error) {
 		return nil, nil
 	})
 }

--- a/body/body_test.go
+++ b/body/body_test.go
@@ -1,7 +1,6 @@
 package body_test
 
 import (
-	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -30,11 +29,10 @@ func TestString(t *testing.T) {
 		{"š", "GET", "POST"},
 	} {
 		middleware := body.String(data.Data)
-		ctx := context.Background()
 		req := cliware.EmptyRequest()
 		req.Method = data.Method
 		h := createHandler()
-		_, err := middleware.Exec(h).Handle(ctx, req)
+		_, err := middleware.Exec(h).Handle(req)
 		if err != nil {
 			t.Error("Got error processing request: ", err)
 		}
@@ -75,7 +73,7 @@ func TestJSON(t *testing.T) {
 	} {
 		req := cliware.EmptyRequest()
 		handler := createHandler()
-		_, err := body.JSON(data.Data).Exec(handler).Handle(nil, req)
+		_, err := body.JSON(data.Data).Exec(handler).Handle(req)
 		if data.ExpectedError != nil {
 			if data.ExpectedError != err {
 				t.Errorf("Wrong error. Expected: %s, got: %s", data.ExpectedError, err)
@@ -138,7 +136,7 @@ func TestXML(t *testing.T) {
 	for _, data := range tests {
 		req := cliware.EmptyRequest()
 		handler := createHandler()
-		_, err := body.XML(data.Data).Exec(handler).Handle(nil, req)
+		_, err := body.XML(data.Data).Exec(handler).Handle(req)
 		if data.ExpectedError != nil {
 			if data.ExpectedError != err {
 				t.Errorf("Wrong error. Expected: %s, got: %s", data.ExpectedError, err)
@@ -191,7 +189,7 @@ func TestReader(t *testing.T) {
 	} {
 		req := cliware.EmptyRequest()
 		handler := createHandler()
-		_, err := body.Reader(data.Reader).Exec(handler).Handle(nil, req)
+		_, err := body.Reader(data.Reader).Exec(handler).Handle(req)
 		if data.ExpectError != nil {
 			if data.ExpectError.Error() != err.Error() {
 				t.Errorf("Wrong error. Expected: %s, got: %s", data.ExpectError.Error(), err.Error())
@@ -206,7 +204,7 @@ func TestReader(t *testing.T) {
 }
 
 func createHandler() cliware.Handler {
-	return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
+	return cliware.HandlerFunc(func(req *http.Request) (resp *http.Response, err error) {
 		return nil, nil
 	})
 }

--- a/cookies/cookies_test.go
+++ b/cookies/cookies_test.go
@@ -1,7 +1,6 @@
 package cookies_test
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -52,7 +51,7 @@ func TestAdd(t *testing.T) {
 		for _, existing := range data.Existing {
 			req.AddCookie(existing)
 		}
-		_, err := chain.Exec(createHandler()).Handle(nil, req)
+		_, err := chain.Exec(createHandler()).Handle(req)
 		if err != nil {
 			t.Error("Handle returned error: ", err)
 		}
@@ -106,7 +105,7 @@ func TestSet(t *testing.T) {
 		for _, existing := range data.Existing {
 			req.AddCookie(existing)
 		}
-		_, err := chain.Exec(createHandler()).Handle(nil, req)
+		_, err := chain.Exec(createHandler()).Handle(req)
 		if err != nil {
 			t.Error("Handle returned error: ", err)
 		}
@@ -141,7 +140,7 @@ func TestDelAll(t *testing.T) {
 		for _, c := range existing {
 			req.AddCookie(c)
 		}
-		_, err := chain.Exec(createHandler()).Handle(nil, req)
+		_, err := chain.Exec(createHandler()).Handle(req)
 		if err != nil {
 			t.Error("Handle returned error: ", err)
 		}
@@ -185,7 +184,7 @@ func TestSetMap(t *testing.T) {
 		for _, c := range data.Existing {
 			req.AddCookie(c)
 		}
-		_, err := chain.Exec(createHandler()).Handle(nil, req)
+		_, err := chain.Exec(createHandler()).Handle(req)
 		if err != nil {
 			t.Error("Handle returned error: ", err)
 		}
@@ -231,7 +230,7 @@ func TestAddMultiple(t *testing.T) {
 		for _, c := range data.Existing {
 			req.AddCookie(c)
 		}
-		_, err := chain.Exec(createHandler()).Handle(nil, req)
+		_, err := chain.Exec(createHandler()).Handle(req)
 		if err != nil {
 			t.Error("Handle returned error: ", err)
 		}
@@ -250,7 +249,7 @@ func TestAddMultiple(t *testing.T) {
 }
 
 func createHandler() cliware.Handler {
-	return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
+	return cliware.HandlerFunc(func(req *http.Request) (resp *http.Response, err error) {
 		return nil, nil
 	})
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -2,7 +2,6 @@ package errors_test
 
 import (
 	"bytes"
-	"context"
 	"net/http"
 	"testing"
 
@@ -83,7 +82,7 @@ func TestErrors(t *testing.T) {
 		m := errors.Errors()
 		req := cliware.EmptyRequest()
 		handler := createHandler(data.Response, data.OriginalError)
-		_, err := m.Exec(handler).Handle(nil, req)
+		_, err := m.Exec(handler).Handle(req)
 
 		if data.Error == nil && data.OriginalError == nil {
 			if err != nil {
@@ -151,7 +150,7 @@ func TestHTTPError_Error(t *testing.T) {
 }
 
 func createHandler(wantedResponse *http.Response, wantError error) cliware.Handler {
-	return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
+	return cliware.HandlerFunc(func(req *http.Request) (resp *http.Response, err error) {
 		return wantedResponse, wantError
 	})
 }

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -61,8 +61,8 @@ type Header struct {
 // FromContext adds header to request that is defined in context with provided key.
 func FromContext(key interface{}) c.Middleware {
 	return c.MiddlewareFunc(func(next c.Handler) c.Handler {
-		return c.HandlerFunc(func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
-			value := ctx.Value(key)
+		return c.HandlerFunc(func(req *http.Request) (resp *http.Response, err error) {
+			value := req.Context().Value(key)
 			switch header := value.(type) {
 			case Header:
 				for _, v := range header.Value {
@@ -77,7 +77,7 @@ func FromContext(key interface{}) c.Middleware {
 			default:
 				return nil, errors.New("headers.FromContext middleware: value in unsupported format")
 			}
-			return next.Handle(ctx, req)
+			return next.Handle(req)
 		})
 	})
 }

--- a/headers/headers_test.go
+++ b/headers/headers_test.go
@@ -20,7 +20,7 @@ func TestMethod(t *testing.T) {
 		m := headers.Method(method)
 		req := cliware.EmptyRequest()
 		handler := createHandler()
-		m.Exec(handler).Handle(nil, req)
+		m.Exec(handler).Handle(req)
 
 		if req.Method != method {
 			t.Errorf("Wrong method. Got: %s, expected: %s", req.Method, method)
@@ -75,7 +75,7 @@ func TestAdd(t *testing.T) {
 		}
 
 		handler := createHandler()
-		m.Exec(handler).Handle(nil, req)
+		m.Exec(handler).Handle(req)
 
 		if len(req.Header) != data.ExpectingHeaders {
 			t.Errorf("Number of headers to not match. Got: %d, expected: %d.", len(req.Header), data.ExpectingHeaders)
@@ -138,7 +138,7 @@ func TestSet(t *testing.T) {
 		}
 
 		handler := createHandler()
-		m.Exec(handler).Handle(nil, req)
+		m.Exec(handler).Handle(req)
 
 		if len(req.Header) != data.ExpectingHeaders {
 			t.Errorf("Number of headers to not match. Got: %d, expected: %d.", len(req.Header), data.ExpectingHeaders)
@@ -189,7 +189,7 @@ func TestDel(t *testing.T) {
 		}
 
 		handler := createHandler()
-		m.Exec(handler).Handle(nil, req)
+		m.Exec(handler).Handle(req)
 
 		_, ok := req.Header[data.Name]
 		if ok {
@@ -253,7 +253,7 @@ func TestSetMap(t *testing.T) {
 		}
 
 		handler := createHandler()
-		m.Exec(handler).Handle(nil, req)
+		m.Exec(handler).Handle(req)
 
 		if !reflect.DeepEqual(data.Expected, req.Header) {
 			t.Errorf("Wrong headers. Got: %s, expected: %s.", req.Header, data.Expected)
@@ -310,7 +310,8 @@ func TestFromContext_HeaderList(t *testing.T) {
 			ctx = context.WithValue(context.Background(), data.Key, data.Value)
 		}
 
-		_, err := m.Exec(createHandler()).Handle(ctx, req)
+		req = req.WithContext(ctx)
+		_, err := m.Exec(createHandler()).Handle(req)
 		if err != nil {
 			if data.ExpectedError == "" {
 				t.Errorf("Did not expect error, got: %s.", data.ExpectedError)
@@ -411,7 +412,7 @@ func TestToContextList(t *testing.T) {
 }
 
 func createHandler() cliware.Handler {
-	return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
+	return cliware.HandlerFunc(func(req *http.Request) (resp *http.Response, err error) {
 		return nil, nil
 	})
 }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -1,7 +1,6 @@
 package query_test
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -41,7 +40,7 @@ func TestSet(t *testing.T) {
 		}
 		req.URL = parsedURL
 		handler := createHandler()
-		m.Exec(handler).Handle(nil, req)
+		m.Exec(handler).Handle(req)
 
 		q, err := neturl.ParseQuery(data.ResultingQuery)
 		if err != nil {
@@ -82,7 +81,7 @@ func TestAdd(t *testing.T) {
 		}
 		req.URL = parsedURL
 		handler := createHandler()
-		m.Exec(handler).Handle(nil, req)
+		m.Exec(handler).Handle(req)
 
 		q, err := neturl.ParseQuery(data.ResultingQuery)
 		if err != nil {
@@ -120,7 +119,7 @@ func TestDel(t *testing.T) {
 		}
 		req.URL = parsedURL
 		handler := createHandler()
-		m.Exec(handler).Handle(nil, req)
+		m.Exec(handler).Handle(req)
 
 		q, err := neturl.ParseQuery(data.ResultingQuery)
 		if err != nil {
@@ -146,7 +145,7 @@ func TestDelAll(t *testing.T) {
 		}
 		req.URL = parsedURL
 		handler := createHandler()
-		m.Exec(handler).Handle(nil, req)
+		m.Exec(handler).Handle(req)
 
 		q := neturl.Values{}
 
@@ -186,7 +185,7 @@ func TestSetMap(t *testing.T) {
 		}
 		req.URL = parsedURL
 		handler := createHandler()
-		m.Exec(handler).Handle(nil, req)
+		m.Exec(handler).Handle(req)
 
 		q, err := neturl.ParseQuery(data.ResultingQuery)
 		if err != nil {
@@ -200,7 +199,7 @@ func TestSetMap(t *testing.T) {
 }
 
 func createHandler() cliware.Handler {
-	return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
+	return cliware.HandlerFunc(func(req *http.Request) (resp *http.Response, err error) {
 		return nil, nil
 	})
 }

--- a/responsebody/responsebody_test.go
+++ b/responsebody/responsebody_test.go
@@ -1,7 +1,6 @@
 package responsebody_test
 
 import (
-	"context"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -36,14 +35,14 @@ func TestJSON(t *testing.T) {
 	} {
 		var body map[string]interface{}
 		req := cliware.EmptyRequest()
-		handler := func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		handler := func(req *http.Request) (*http.Response, error) {
 			r := &http.Response{
 				Body: ioutil.NopCloser(strings.NewReader(data.RawData)),
 			}
 			return r, data.Error
 		}
 
-		_, err := responsebody.JSON(&body).Exec(cliware.HandlerFunc(handler)).Handle(nil, req)
+		_, err := responsebody.JSON(&body).Exec(cliware.HandlerFunc(handler)).Handle(req)
 		if err != nil && data.Error == nil {
 			t.Error("Got unexpected error: ", err)
 		}
@@ -78,13 +77,13 @@ func TestString(t *testing.T) {
 	} {
 		var body string
 		req := cliware.EmptyRequest()
-		handler := func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		handler := func(req *http.Request) (*http.Response, error) {
 			r := &http.Response{
 				Body: ioutil.NopCloser(strings.NewReader(data.Data)),
 			}
 			return r, data.Error
 		}
-		_, err := responsebody.String(&body).Exec(cliware.HandlerFunc(handler)).Handle(nil, req)
+		_, err := responsebody.String(&body).Exec(cliware.HandlerFunc(handler)).Handle(req)
 		if err != nil && data.Error == nil {
 			t.Error("Got unexpected error: ", err)
 		}
@@ -119,13 +118,13 @@ func TestWriter(t *testing.T) {
 	} {
 		buf := &bytes.Buffer{}
 		req := cliware.EmptyRequest()
-		handler := func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		handler := func(req *http.Request) (*http.Response, error) {
 			r := &http.Response{
 				Body: ioutil.NopCloser(strings.NewReader(data.Data)),
 			}
 			return r, data.Error
 		}
-		_, err := responsebody.Writer(buf).Exec(cliware.HandlerFunc(handler)).Handle(nil, req)
+		_, err := responsebody.Writer(buf).Exec(cliware.HandlerFunc(handler)).Handle(req)
 		if err != nil && data.Error == nil {
 			t.Error("Got unexpected error: ", err)
 		}

--- a/url/url_test.go
+++ b/url/url_test.go
@@ -5,8 +5,6 @@ import (
 	neturl "net/url"
 	"testing"
 
-	"context"
-
 	"reflect"
 
 	"github.com/delicb/cliware"
@@ -22,7 +20,7 @@ func testURLMiddleware(t *testing.T, data []testData, factory func(r *http.Reque
 	for _, d := range data {
 		req := cliware.EmptyRequest()
 		handler := createHandler()
-		factory(req, d).Exec(handler).Handle(nil, req)
+		factory(req, d).Exec(handler).Handle(req)
 		if !reflect.DeepEqual(req.URL, d.URL) {
 			t.Errorf("URL did not match. Got: \"%s\", expected: \"%s\".", req.URL, d.URL)
 		}
@@ -30,7 +28,7 @@ func testURLMiddleware(t *testing.T, data []testData, factory func(r *http.Reque
 }
 
 func createHandler() cliware.Handler {
-	return cliware.HandlerFunc(func(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
+	return cliware.HandlerFunc(func(req *http.Request) (resp *http.Response, err error) {
 		return nil, nil
 	})
 }
@@ -123,7 +121,7 @@ func TestParam(t *testing.T) {
 		req := cliware.EmptyRequest()
 		req.URL.Path = data.InitialPath
 		handler := createHandler()
-		url.Param(data.ParamKey, data.ParamValue).Exec(handler).Handle(nil, req)
+		url.Param(data.ParamKey, data.ParamValue).Exec(handler).Handle(req)
 
 		if req.URL.Path != data.ResultPath {
 			t.Errorf("Got wrong path. Got: %s, expected: %s.", req.URL.Path, data.ResultPath)
@@ -163,7 +161,7 @@ func TestParams(t *testing.T) {
 		req := cliware.EmptyRequest()
 		req.URL.Path = data.InitialPath
 		handler := createHandler()
-		url.Params(data.Params).Exec(handler).Handle(nil, req)
+		url.Params(data.Params).Exec(handler).Handle(req)
 
 		if req.URL.Path != data.ResultPath {
 			t.Errorf("Got wrong path. Got: %s, expected: %s.", req.URL.Path, data.ResultPath)


### PR DESCRIPTION
Request already has context, so providing an additional context.Context is redundant.
This pull request contains breaking API changes.